### PR TITLE
docs: add tutorials for registering Oracle FDW and setting up cron jobs for sync data to local

### DIFF
--- a/tutorials/fdw/1.register_fdw_table.md
+++ b/tutorials/fdw/1.register_fdw_table.md
@@ -1,0 +1,63 @@
+# Register the foreign data wrapper
+
+## Oracle Foreign Data Wrapper
+
+1. Install the Oracle Foreign Data Wrapper extension in PostgreSQL:
+
+    ```sql
+    CREATE EXTENSION IF NOT EXISTS oracle_fdw;
+    ```
+
+2. Create a server for the Oracle database:
+
+    ```sql
+    CREATE SERVER oracle_server
+        FOREIGN DATA WRAPPER oracle_fdw
+        OPTIONS (dbserver '//oracle_host:1521/orcl');
+    ```
+
+    or using a TNS connection string:
+
+    ```sql
+    -- or connect with TNS service
+    CREATE SERVER oracle_server
+    FOREIGN DATA WRAPPER oracle_fdw
+    OPTIONS (dbserver
+    '(description=(load_balance=on)(failover=on)
+    (address_list=(source_route=yes)
+        (address=(protocol=tcp)(host=oracle-host)(port=1521))
+        (address=(protocol=tcp)(host=oracle-host)(port=1522))
+    )
+    (connect_data=(service_name=ORCLPDB1)))');
+    ```
+
+Replace `oracle-host` with your Oracle server's hostname or IP address, and `ORCLPDB1` with your Oracle service name.
+
+3. Create a user mapping for the Oracle FDW:
+
+    ```sql
+    CREATE USER MAPPING FOR CURRENT_USER
+    SERVER oracle_server
+    OPTIONS (user 'oracle_user', password 'oracle_password');
+    ```
+
+Replace `oracle_user` and `oracle_password` with your Oracle database credentials.
+
+4. Create a foreign table that maps to an Oracle table:
+
+    ```sql
+    CREATE FOREIGN TABLE oracle_employees (
+        employee_id integer,
+        first_name text,
+        last_name text,
+        updated_at timestamp(6) DEFAULT now() NULL
+    )
+    SERVER oracle_server
+    OPTIONS (schema 'HR', table 'EMPLOYEES');
+    ```
+
+5. Query the foreign table to verify the connection:
+
+    ```sql
+    SELECT * FROM oracle_employees LIMIT 10;
+    ```

--- a/tutorials/fdw/2.cron_fdw_to_local.md
+++ b/tutorials/fdw/2.cron_fdw_to_local.md
@@ -39,7 +39,17 @@ You can set up a cron job to periodically load data from a foreign table (e.g., 
 1. Create a configuration table to manage which tables to sync and their sync frequency:
 
     ```sql
-    CREATE TABLE public.cron_table_sync_config ( id serial4 NOT NULL, source_table text NULL, target_table text NULL, primary_keys _text NOT NULL, target_updated_date_field text NULL, enabled bool DEFAULT true NULL, last_sync_time timestamp NULL, sync_frequency interval DEFAULT '00:01:00'::interval NULL, CONSTRAINT cron_table_sync_config_pkey PRIMARY KEY (id));
+    CREATE TABLE public.cron_table_sync_config (
+        id serial4 NOT NULL,
+        source_table text NULL,
+        target_table text NULL,
+        primary_keys _text NOT NULL,
+        target_updated_date_field text NULL,
+        enabled bool DEFAULT true NULL,
+        last_sync_time timestamp NULL,
+        sync_frequency interval DEFAULT '00:01:00'::interval NULL,
+        CONSTRAINT cron_table_sync_config_pkey PRIMARY KEY (id)
+    );
     ```
 
 2. Create a logging table to track sync operations:

--- a/tutorials/fdw/2.cron_fdw_to_local.md
+++ b/tutorials/fdw/2.cron_fdw_to_local.md
@@ -55,7 +55,18 @@ You can set up a cron job to periodically load data from a foreign table (e.g., 
 2. Create a logging table to track sync operations:
 
     ```sql
-    CREATE TABLE public.sync_operation_logs ( id serial4 NOT NULL, source_table text NULL, target_table text NULL, start_time timestamp NULL, end_time timestamp NULL, status text NULL, rows_affected int8 NULL, message text NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP NULL, CONSTRAINT sync_operation_logs_pkey PRIMARY KEY (id));
+    CREATE TABLE public.sync_operation_logs (
+        id serial4 NOT NULL,
+        source_table text NULL,
+        target_table text NULL,
+        start_time timestamp NULL,
+        end_time timestamp NULL,
+        status text NULL,
+        rows_affected int8 NULL,
+        message text NULL,
+        created_at timestamp DEFAULT CURRENT_TIMESTAMP NULL,
+        CONSTRAINT sync_operation_logs_pkey PRIMARY KEY (id)
+    );
     ```
 
 3. Create function to sync data from foreign table to local table:

--- a/tutorials/fdw/2.cron_fdw_to_local.md
+++ b/tutorials/fdw/2.cron_fdw_to_local.md
@@ -1,0 +1,268 @@
+# Cron job to load foreign table data to local postgres table
+
+You can set up a cron job to periodically load data from a foreign table (e.g., an Oracle table accessed via `oracle_fdw`) into a local PostgreSQL table. Below are the steps to achieve this.
+
+## PG CRON
+
+### Pre-requisites:
+
+1. Ensure that the PostgreSQL server is running and accessible.
+2. `pg_cron` in `shared_preload_libraries`:
+
+    ``` yaml
+      postgresql:
+        shared_preload_libraries:
+        - pg_cron
+    ```
+
+3. Ensure FDW is set up and working (see [Register the foreign data wrapper](1.register_fdw_table.md))
+
+
+### Steps:
+
+1. Install the `pg_cron` extension if it's not already installed:
+
+    ```sql
+    CREATE EXTENSION IF NOT EXISTS pg_cron;
+    ```
+
+2. Grant necessary permissions to the user who will run the cron jobs:
+
+    ```sql
+    GRANT USAGE ON SCHEMA cron TO app;
+    -- Grant permissions on cron schema tables
+    GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA cron TO app;
+    ```
+
+### Create tables and function to control cron jobs
+
+1. Create a configuration table to manage which tables to sync and their sync frequency:
+
+    ```sql
+    CREATE TABLE public.cron_table_sync_config ( id serial4 NOT NULL, source_table text NULL, target_table text NULL, primary_keys _text NOT NULL, target_updated_date_field text NULL, enabled bool DEFAULT true NULL, last_sync_time timestamp NULL, sync_frequency interval DEFAULT '00:01:00'::interval NULL, CONSTRAINT cron_table_sync_config_pkey PRIMARY KEY (id));
+    ```
+
+2. Create a logging table to track sync operations:
+
+    ```sql
+    CREATE TABLE public.sync_operation_logs ( id serial4 NOT NULL, source_table text NULL, target_table text NULL, start_time timestamp NULL, end_time timestamp NULL, status text NULL, rows_affected int8 NULL, message text NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP NULL, CONSTRAINT sync_operation_logs_pkey PRIMARY KEY (id));
+    ```
+
+3. Create function to sync data from foreign table to local table:
+
+    ```sql
+    CREATE OR REPLACE FUNCTION public.sync_table_data(source_table text, target_table text, pk_columns text[], updated_date_column text)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $function$
+        DECLARE
+            pk_list text;
+            column_list text;
+            target_column_list text;
+            update_list text;
+            delete_condition text;
+            temp_table_name text;
+            sql_statement text;
+        BEGIN
+            -- Generate a unique temporary table name
+            temp_table_name := 'temp_' || md5(random()::text || clock_timestamp()::text)::varchar(20);
+
+            -- Get the column list dynamically
+            SELECT string_agg(quote_ident(column_name), ', ')
+            INTO target_column_list
+            FROM information_schema.columns
+            WHERE table_name = target_table
+                AND table_schema = current_schema();
+            
+            SELECT string_agg(format('%I as %I', upper(col), col), ',') from (
+                select quote_ident(column_name) col 
+                FROM information_schema.columns
+                WHERE table_name = target_table
+                AND table_schema = current_schema()
+            ) 
+            INTO column_list;
+
+            -- Create the primary key conflict list
+            pk_list := array_to_string(array(SELECT quote_ident(pk) FROM unnest(pk_columns) pk), ', ');
+
+            -- Create the update list for all columns except primary keys
+            SELECT string_agg(format('%I = EXCLUDED.%I', column_name, column_name), ', ')
+            INTO update_list
+            FROM information_schema.columns
+            WHERE table_name = target_table
+            AND table_schema = current_schema()
+            AND column_name != ALL(pk_columns);
+
+            RAISE WARNING 'update_list: % ', update_list;	
+
+            -- Create a temporary table with the source data
+            EXECUTE format('CREATE TEMPORARY TABLE %I AS SELECT %s FROM %I', temp_table_name, column_list, source_table);
+
+            RAISE WARNING 'CREATE TEMPORARY TABLE % AS SELECT % FROM %', temp_table_name, column_list, source_table;
+
+            -- Perform the UPSERT operation
+            sql_statement := format(
+                'INSERT INTO %I SELECT %s FROM %I ON CONFLICT (%s) DO UPDATE SET %s ' ||
+                'WHERE %I.%I IS DISTINCT FROM EXCLUDED.%I',
+                target_table,
+                target_column_list,
+                temp_table_name,
+                LOWER(pk_list),
+                update_list,
+                target_table,
+                updated_date_column,
+                updated_date_column
+            );
+
+        --	RAISE WARNING 'Perform UPSERT operation %', sql_statement;
+            EXECUTE sql_statement;
+
+            -- Create the delete condition
+            SELECT string_agg(format('%I.%I IS NULL', temp_table_name, lower(pk)), ' AND ')
+            INTO delete_condition
+            FROM unnest(pk_columns) pk;
+
+            -- Remove rows from target that don't exist in source
+            sql_statement := format(
+                'DELETE FROM %I WHERE NOT EXISTS (SELECT 1 FROM %I WHERE %s)',
+                target_table,
+                temp_table_name,
+                array_to_string(array(
+                    SELECT format('%I.%I = %I.%I', target_table, lower(pk), temp_table_name, lower(pk))
+                    FROM unnest(pk_columns) pk
+                ), ' AND ')
+            );
+            EXECUTE sql_statement;
+
+            -- Drop the temporary table
+            EXECUTE format('DROP TABLE %I', temp_table_name);
+
+        EXCEPTION WHEN OTHERS THEN
+            -- Ensure temporary table is dropped even if an error occurs
+            EXECUTE format('DROP TABLE IF EXISTS %I', temp_table_name);
+            RAISE;
+        END;
+        $function$
+    ;
+    ```
+
+4. Create function to sync all enabled tables based on their frequency in `cron_table_sync_config`:
+
+    ```sql
+    CREATE OR REPLACE FUNCTION public.sync_all_tables()
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $function$
+        DECLARE
+            config_row RECORD;
+            start_time timestamp;
+            end_time timestamp;
+            rows_affected bigint;
+            rows_deleted bigint;
+        BEGIN
+            FOR config_row IN 
+                SELECT * FROM cron_table_sync_config 
+                WHERE enabled = true 
+                AND (last_sync_time IS NULL OR 
+                    current_timestamp - last_sync_time >= sync_frequency)
+            LOOP
+                BEGIN
+                    start_time := clock_timestamp();
+                    
+                    -- Get initial row count
+                    EXECUTE format('SELECT count(*) FROM %I', config_row.target_table) INTO rows_affected;
+
+                    -- Perform the sync operation
+                    PERFORM sync_table_data(
+                        config_row.source_table,
+                        config_row.target_table,
+                        config_row.primary_keys,
+                        config_row.target_updated_date_field
+                    );
+
+                    end_time := clock_timestamp();
+                    
+                    -- Get final row count and calculate deleted rows
+                    EXECUTE format('SELECT count(*) FROM %I', config_row.target_table) 
+                    INTO rows_deleted;
+                    rows_deleted := rows_affected - rows_deleted;
+                    rows_affected := rows_affected + rows_deleted;
+
+                    -- Log successful sync
+                    INSERT INTO sync_operation_logs (
+                        source_table,
+                        target_table,
+                        start_time,
+                        end_time,
+                        status,
+                        rows_affected,
+                        message
+                    ) VALUES (
+                        config_row.source_table,
+                        config_row.target_table,
+                        start_time,
+                        end_time,
+                        'SUCCESS',
+                        rows_affected,
+                        format('Synced %s rows (Deleted %s rows)', rows_affected, rows_deleted)
+                    );
+                    
+                    -- Update last sync time
+                    UPDATE cron_table_sync_config 
+                    SET last_sync_time = end_time 
+                    WHERE id = config_row.id;
+
+                EXCEPTION WHEN OTHERS THEN
+                    -- Log error
+                    INSERT INTO sync_operation_logs (
+                        source_table,
+                        target_table,
+                        start_time,
+                        end_time,
+                        status,
+                        message
+                    ) VALUES (
+                        config_row.source_table,
+                        config_row.target_table,
+                        start_time,
+                        clock_timestamp(),
+                        'ERROR',
+                        SQLERRM
+                    );
+                    
+                    -- Continue with next table
+                    CONTINUE;
+                END;
+            END LOOP;
+        END;
+        $function$
+        ;
+    ```
+
+5. Schedule the `sync_all_tables` function to run at a desired interval (e.g., every minute):
+
+    There are default function to schedule cron jobs in the `cron` schema. You can use `cron.schedule_in_database` to schedule the job with more control.
+
+    Here is the definition of `cron.schedule_in_database`:
+    
+    ``` sql
+    CREATE OR REPLACE FUNCTION cron.schedule_in_database(job_name text, schedule text, command text, database text, username text DEFAULT NULL::text, active boolean DEFAULT true)
+    RETURNS bigint
+    LANGUAGE c
+    AS '$libdir/pg_cron', $function$cron_schedule_named$function$
+    ;    
+    ```
+
+    To schedule the job, run:
+
+    ```sql
+    select cron.schedule_in_database('job_name','* * * * *', 'SELECT public.sync_all_tables()','app','app', true);
+    ```
+
+6. Insert configuration for tables to sync:
+
+    ```sql
+    INSERT INTO public.cron_table_sync_config (source_table, target_table, primary_keys, target_updated_date_field, enabled, sync_frequency)
+    VALUES 
+    ('oracle_employees', 'employees', ARRAY['employee_id'], 'updated_at', true, '00:05:00'::interval)
+    ```

--- a/tutorials/fdw/2.cron_fdw_to_local.md
+++ b/tutorials/fdw/2.cron_fdw_to_local.md
@@ -203,11 +203,17 @@ You can set up a cron job to periodically load data from a foreign table (e.g., 
 
                     end_time := clock_timestamp();
                     
-                    -- Get final row count and calculate deleted rows
+                    -- Get final row count and calculate changes
+                    DECLARE initial_count bigint := rows_affected;
+                    
                     EXECUTE format('SELECT count(*) FROM %I', config_row.target_table) 
-                    INTO rows_deleted;
-                    rows_deleted := rows_affected - rows_deleted;
-                    rows_affected := rows_affected + rows_deleted;
+                    INTO rows_affected;  -- Now contains final count
+                    
+                    -- Calculate deleted rows (negative means net deletions)
+                    rows_deleted := initial_count - rows_affected;
+                    
+                    -- Set rows_affected to show net change magnitude
+                    rows_affected := ABS(rows_deleted);
 
                     -- Log successful sync
                     INSERT INTO sync_operation_logs (


### PR DESCRIPTION
This pull request adds comprehensive documentation for setting up and automating the synchronization of Oracle tables into PostgreSQL using Foreign Data Wrapper (FDW) and `pg_cron`. The changes provide step-by-step instructions for registering the Oracle FDW, creating required tables and functions for sync operations, and scheduling periodic data loads via cron jobs.

**Foreign Data Wrapper setup:**

* Added instructions for installing and configuring the Oracle FDW extension in PostgreSQL, including examples for both standard and TNS connection strings. (`tutorials/fdw/1.register_fdw_table.md`, [tutorials/fdw/1.register_fdw_table.mdR1-R63](diffhunk://#diff-b9c669f7a8f454632486bbffd2185600d21f01775cbaf3f1f59f81d8dfb670e4R1-R63))
* Provided SQL commands to create a foreign server, user mapping, and foreign table mapping to an Oracle table, with guidance on customizing connection parameters. (`tutorials/fdw/1.register_fdw_table.md`, [tutorials/fdw/1.register_fdw_table.mdR1-R63](diffhunk://#diff-b9c669f7a8f454632486bbffd2185600d21f01775cbaf3f1f59f81d8dfb670e4R1-R63))

**Automated sync with pg_cron:**

* Documented prerequisites and setup for enabling the `pg_cron` extension, including permissions and configuration recommendations. (`tutorials/fdw/2.cron_fdw_to_local.md`, [tutorials/fdw/2.cron_fdw_to_local.mdR1-R268](diffhunk://#diff-48ecb5799badde56897bc04b9ff8b87565e357cbb3e544ade52276e8d48094adR1-R268))
* Added SQL examples for creating configuration and logging tables to manage sync operations and track their status. (`tutorials/fdw/2.cron_fdw_to_local.md`, [tutorials/fdw/2.cron_fdw_to_local.mdR1-R268](diffhunk://#diff-48ecb5799badde56897bc04b9ff8b87565e357cbb3e544ade52276e8d48094adR1-R268))
* Introduced robust PL/pgSQL functions for syncing data from foreign tables to local tables, handling upserts, deletes, and error logging, as well as a master function for syncing multiple tables based on config. (`tutorials/fdw/2.cron_fdw_to_local.md`, [tutorials/fdw/2.cron_fdw_to_local.mdR1-R268](diffhunk://#diff-48ecb5799badde56897bc04b9ff8b87565e357cbb3e544ade52276e8d48094adR1-R268))
* Provided instructions and examples for scheduling sync jobs using `cron.schedule_in_database`, and for configuring which tables to sync and their frequency. (`tutorials/fdw/2.cron_fdw_to_local.md`, [tutorials/fdw/2.cron_fdw_to_local.mdR1-R268](diffhunk://#diff-48ecb5799badde56897bc04b9ff8b87565e357cbb3e544ade52276e8d48094adR1-R268))